### PR TITLE
webview图片显示优化

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -15,6 +15,7 @@ webview/src/*/css/**
 webview/src/*/js/**
 webview/src/*/*.development.*
 webview/*.css
+webview/*.js
 test/**
 filePackage/**
 fileicons/**

--- a/package.json
+++ b/package.json
@@ -154,9 +154,10 @@
 		}
 	},
 	"scripts": {
-		"vscode:prepublish": "ts-node src/filePackage/check.ts && npm run compile",
+		"vscode:prepublish": "npm run check && npm run compile",
 		"compile": "rollup -c",
 		"pre": "ts-node src/filePackage/production.ts",
+		"check": "ts-node src/filePackage/check.ts",
 		"watch": "tsc -watch -p ./",
 		"pretest": "npm run compile && npm run lint",
 		"lint": "eslint src --ext ts",

--- a/src/backgroundImage/data.d.ts
+++ b/src/backgroundImage/data.d.ts
@@ -10,8 +10,8 @@ interface dataType {
  * 接收通信数据类型
  */
 
-export type backgroundMessageData = backgroundInitType | selectImageType | deleteImageType | settingBackgroundType | 
-    externalImageType | backgroundOpacityType | randomBackgroundType | viewBigImageType;
+export type backgroundMessageData = backgroundInitType | getBackgroundBase64DataType | selectImageType | deleteImageType | settingBackgroundType | 
+externalImageType | backgroundOpacityType | randomBackgroundType | viewBigImageType;
 
 /**
  * 脚本侧通知初始化背景图信息
@@ -19,6 +19,14 @@ export type backgroundMessageData = backgroundInitType | selectImageType | delet
 interface backgroundInitType extends dataType {
     name: 'backgroundInit';
     value: boolean;
+}
+
+/**
+ * webview脚本侧通过code获取具体的base64数据
+ */
+interface getBackgroundBase64DataType extends dataType {
+    name: 'getBackgroundBase64Data';
+    value: { code: string, type: string };
 }
 
 /**
@@ -78,21 +86,29 @@ interface randomBackgroundType extends dataType {
 */
 interface viewBigImageType extends dataType {
     name: 'viewBigImage',
-    value: { code: string, src: string }
+    value: string
 }
 
 /**
  * 发送通信信息类型
 */
-export type backgroundSendMessageData = backgroundInitDataType | newImageType | deleteImageSuccessType | settingBackgroundSuccessType | 
-    newImageNetworkType | nowBackgroundOpacityType | backgroundStorePathChangeType | backgroundRandomListType;
+export type backgroundSendMessageData = backgroundInitDataType | backgroundSendBase64DataType | newImageType | deleteImageSuccessType | 
+settingBackgroundSuccessType | newImageNetworkType | nowBackgroundOpacityType | backgroundStorePathChangeType | backgroundRandomListType;
 
 /**
  * 通知脚本侧背景图信息初始化完成，返回所有背景图数据
  */
 interface backgroundInitDataType extends dataType {
     name: 'backgroundInitData';
-    value: string[][];
+    value: string[];
+}
+
+/**
+ * 发送图片具体的base64数据
+ */
+interface backgroundSendBase64DataType extends dataType {
+    name: 'backgroundSendBase64Data';
+    value: { code: string, data: string, type: string };
 }
 
 /**

--- a/src/backgroundImage/execute.ts
+++ b/src/backgroundImage/execute.ts
@@ -1,5 +1,5 @@
 import { Webview } from "vscode";
-import { backgroundImageDataInit, deleteImage, selectImage } from ".";
+import { backgroundImageDataInit, deleteImage, getBase64DataByCode, getBase64DataFromObject, selectImage } from ".";
 import { backgroundMessageData } from "./data";
 import { backgroundOpacityModify, requestImageToBackground } from "./modifyByInput";
 import { randomSettingBackground } from "./modifyRandom";
@@ -21,6 +21,10 @@ export function backgroundExecute ({ name, value }: backgroundMessageData, webvi
             // 初始化背景图数据 value: false | true
             if (value) backgroundImageDataInit();
             break;
+        case 'getBackgroundBase64Data':
+            // 发送code，用于获取具体base64数据
+            if (value) getBase64DataByCode(value);
+            break;
         case 'selectImage':
             // 选择图片 value: false | true
             if (value) selectImage();
@@ -34,6 +38,7 @@ export function backgroundExecute ({ name, value }: backgroundMessageData, webvi
             if (value) settingImage(value);
             break;
         case 'externalImage':
+            // 上传外部图片
             if (value) requestImageToBackground(value);
             break;
         case 'backgroundOpacity':
@@ -45,8 +50,8 @@ export function backgroundExecute ({ name, value }: backgroundMessageData, webvi
             randomSettingBackground(value);
             break;
         case 'viewBigImage':
-            // 标题发送哈希码前七位
-            toViewImage(value.src, `${value.code.slice(0, 7)}...`, webview);
+            // 查看大图，标题发送哈希码前七位
+            if (value) toViewImage(getBase64DataFromObject(value), `${value.slice(0, 7)}...`, webview);
             break;
         default:
             break;

--- a/src/backgroundImage/modify.ts
+++ b/src/backgroundImage/modify.ts
@@ -22,21 +22,35 @@ const cssName = version >= '1.38' ? 'workbench.desktop.main.css' : 'workbench.ma
  */
 const externalFileName = 'backgroundImageInfo.css';
 
-const tagName = 'wangyige.background'; // 标签名
-const tagNameReg = 'wangyige\\.background'; // 标签名正则
-const importStart = `/* ${tagName}.start */`; // 开始标签
-const importEnd = `/* ${tagName}.end */`; // 结束标签
-const importStartMatch = `\\/\\*\\s\*${tagNameReg}\\.start\\s\*\\*\\/`; // 匹配开始标签正则
-const importEndMatch = `\\/\\*\\s\*${tagNameReg}\\.end\\s\*\\*\\/`; // 匹配结束标签正则
+/** 标签名 */
+const tagName = 'wangyige.background'; 
+/** 标签名正则 */
+const tagNameReg = 'wangyige\\.background'; 
+/** 开始标签 */
+const importStart = `/* ${tagName}.start */`; 
+/** 结束标签 */
+const importEnd = `/* ${tagName}.end */`; 
+/** 匹配开始标签正则 */
+const importStartMatch = `\\/\\*\\s\*${tagNameReg}\\.start\\s\*\\*\\/`; 
+/** 匹配结束标签正则 */
+const importEndMatch = `\\/\\*\\s\*${tagNameReg}\\.end\\s\*\\*\\/`; 
 
-const s = '\\s\*'; // 任意空格
-const a = '\[\\s\\S\]\*'; // 任意字符
-const ans = '\\S\*'; // 任意字符不包括空格
-const ant = '\.\*'; // 任意字符不包括换行
-const asa = '\\S\*\.\*\\S\{1\,\}';// 非空格开头非空格结尾，中间允许有空格，必须以非空格结尾
-const n = '\\d\*'; // 任意数字
-const w = '\\w\*'; // 任意单词
-const nw = '[\\d\\w]\*'; // 任意单词和数字
+/** 任意空格 */
+const s = '\\s\*'; 
+/** 任意字符 */
+const a = '\[\\s\\S\]\*'; 
+/** 任意字符不包括空格 */
+const ans = '\\S\*'; 
+/** 任意字符不包括换行 */
+const ant = '\.\*'; 
+/** 非空格开头非空格结尾，中间允许有空格，必须以非空格结尾 */
+const asa = '\\S\*\.\*\\S\{1\,\}' 
+/** 任意数字 */
+const n = '\\d\*'; 
+/** 任意单词 */
+const w = '\\w\*'; 
+/** 任意单词和数字 */
+const nw = '[\\d\\w]\*'; 
 
 /**
  * 匹配源及外部css文件修改内容标签范围正则文本，捕获标签中的内容
@@ -87,37 +101,33 @@ const externalCssOpacityModifyRegexp = new RegExp(externalCssOpacityModify);
  */
 export function modifyCssFileForBackground (codeValue: string, random: boolean = false): Promise<void> {
     return new Promise((resolve, reject) => {
-        try {
-            if (!codeValue) {
-                reject(new Error('null code'));
-                return;
-            }
-            let infoContent: info | undefined;
-            getExternalCssContent(codeValue).then(res => {
-                if (res === false) {
-                    // 不需要更新，直接跳出
-                    throw { jump: true };
-                }
-                infoContent = res[1];
-                return writeExternalCssFile(res[0]);
-            }).then(() => {
-                return settingConfiguration(infoContent!, random);
-            }).then(() => {
-                return setSourceCssImportInfo();
-            }).then(() => {
-                setBackgroundImageSuccess();
-                resolve();
-            }).catch(err => {
-                // 传递了jump属性就resolve
-                if (err.jump) {
-                    resolve();
-                } else {
-                    reject(err);
-                }
-            });
-        } catch (error) {
-            errHandle(error);
+        if (!codeValue) {
+            reject(new Error('null code'));
+            return;
         }
+        let infoContent: info | undefined;
+        getExternalCssContent(codeValue).then(res => {
+            if (res === false) {
+                // 不需要更新，直接跳出
+                throw { jump: true };
+            }
+            infoContent = res[1];
+            return writeExternalCssFile(res[0]);
+        }).then(() => {
+            return settingConfiguration(infoContent!, random);
+        }).then(() => {
+            return setSourceCssImportInfo();
+        }).then(() => {
+            setBackgroundImageSuccess();
+            resolve();
+        }).catch(err => {
+            // 传递了jump属性就resolve
+            if (err.jump) {
+                resolve();
+            } else {
+                reject(err);
+            }
+        });
     });
 }
 
@@ -126,36 +136,32 @@ export function modifyCssFileForBackground (codeValue: string, random: boolean =
  */
 export function deletebackgroundCssFileModification (): Promise<void> {
     return new Promise((resolve, reject) => {
-        try {
-            getSourceCssFileContent().then(data => {
-                if (data) {
-                    // 删除源css文件
-                    return deleteContentByTagName(...data);
-                }
-            }).then(data => {
-                if (data) {
-                    const { content, uri } = data!;
-                    return writeFileUri(uri, createBuffer(content));
-                }
-            }).then(() => {
-                // 删除外部css文件
-                return getExternalFileContent();
-            }).then(data => {
+        getSourceCssFileContent().then(data => {
+            if (data) {
+                // 删除源css文件
                 return deleteContentByTagName(...data);
-            }).then(({ content, uri }) => {
-                return uriDelete(uri);
-            }).then(() => {
-                return deleteConfiguration();
-            }).then(() => {
-                setBackgroundImageSuccess("背景图配置删除成功");
-                isWindowReloadToLoadBackimage("背景图配置删除成功，是否重启窗口");
-                resolve();
-            }).catch(err => {
-                reject(err);
-            });
-        } catch (error) {
-            errHandle(error);
-        }
+            }
+        }).then(data => {
+            if (data) {
+                const { content, uri } = data!;
+                return writeFileUri(uri, createBuffer(content));
+            }
+        }).then(() => {
+            // 删除外部css文件
+            return getExternalFileContent();
+        }).then(data => {
+            return deleteContentByTagName(...data);
+        }).then(({ content, uri }) => {
+            return uriDelete(uri);
+        }).then(() => {
+            return deleteConfiguration();
+        }).then(() => {
+            setBackgroundImageSuccess("背景图配置删除成功");
+            isWindowReloadToLoadBackimage("背景图配置删除成功，是否重启窗口");
+            resolve();
+        }).catch(err => {
+            reject(err);
+        });
     });
 }
 
@@ -165,38 +171,34 @@ export function deletebackgroundCssFileModification (): Promise<void> {
  */
 export function checExternalDataIsRight (): Promise<{modify:boolean}> {
     return new Promise((resolve, reject) => {
-        try {
-            getNowSettingCode().then(res => {
-                if (res) {
-                    return checkCurentImageIsSame(res);
-                } else {
-                    changeLoadState();
-                    throw { jump: true, modify: false };
-                }
-            }).then(data => {
-                const state = data!.state;
-                if (state === true) {
-                    // 当前不需要更新背景图css数据设置文件
-                    throw { jump: true, modify: false };
-                }
-                if (data && data.code) {
-                    // 编码校验失败或者没有css文件，重新写入
-                    return modifyCssFileForBackground(data.code);
-                } else {
-                    throw { jump: true, modify: true };
-                }
-            }).then(() => {
-                resolve({ modify:true });
-            }).catch(err => {
-                if (err.jump) {
-                    resolve({ modify: err.modify });
-                } else {
-                    reject(err);
-                }
-            });
-        } catch (error) {
-            errHandle(error);
-        }
+        getNowSettingCode().then(res => {
+            if (res) {
+                return checkCurentImageIsSame(res);
+            } else {
+                changeLoadState();
+                throw { jump: true, modify: false };
+            }
+        }).then(data => {
+            const state = data!.state;
+            if (state === true) {
+                // 当前不需要更新背景图css数据设置文件
+                throw { jump: true, modify: false };
+            }
+            if (data && data.code) {
+                // 编码校验失败或者没有css文件，重新写入
+                return modifyCssFileForBackground(data.code);
+            } else {
+                throw { jump: true, modify: true };
+            }
+        }).then(() => {
+            resolve({ modify:true });
+        }).catch(err => {
+            if (err.jump) {
+                resolve({ modify: err.modify });
+            } else {
+                reject(err);
+            }
+        });
     });
 }
 
@@ -207,45 +209,41 @@ export function checExternalDataIsRight (): Promise<{modify:boolean}> {
  */
 export function setSourceCssImportInfo (init: boolean = false) : Promise<{modify:boolean}> {
     return new Promise((resolve, reject) => {
-        try {
-            getSourceCssFileContent().then(data => {
-                if (data) {
-                    // 有数据，进行修改
-                    return isSourceCssFileModify(...data);
+        getSourceCssFileContent().then(data => {
+            if (data) {
+                // 有数据，进行修改
+                return isSourceCssFileModify(...data);
+            } else {
+                // 没有数据返回false
+                throw { jump: true, modify: false };
+            }
+        }).then(({ content, uri, exits }) => {
+            const nowDate = new Date().getTime();
+            let resContent: Buffer;
+            if (exits === true) {
+                // 修改过源文件需要更换路径后的时间戳，去除缓存
+                if (!init) {
+                    resContent = createBuffer(content.replace(findSourceCssVersionContentRegexp, `$1${nowDate}$3`));
                 } else {
-                    // 没有数据返回false
+                    // 源文件满足修改格式并且当前是初始化校验调用，则不进行文件改写并且通知外部函数当前未修改
                     throw { jump: true, modify: false };
                 }
-            }).then(({ content, uri, exits }) => {
-                const nowDate = new Date().getTime();
-                let resContent: Buffer;
-                if (exits === true) {
-                    // 修改过源文件需要更换路径后的时间戳，去除缓存
-                    if (!init) {
-                        resContent = createBuffer(content.replace(findSourceCssVersionContentRegexp, `$1${nowDate}$3`));
-                    } else {
-                        // 源文件满足修改格式并且当前是初始化校验调用，则不进行文件改写并且通知外部函数当前未修改
-                        throw { jump: true, modify: false };
-                    }
-                } else {
-                    // 没有修改过源文件直接修改
-                    resContent = createBuffer(`${importStart+'\n'
-                        }@import url("./${externalFileName}?${nowDate}");${
-                        '\n'+importEnd}`+content);
-                }
-                return writeFileUri(uri, resContent);
-            }).then(() => {
-                resolve({ modify: true });
-            }).catch(err => {
-                if (err.jump) {
-                    resolve({ modify: err.modify });
-                } else {
-                    reject(err);
-                }
-            });
-        } catch (error) {
-            errHandle(error);
-        }
+            } else {
+                // 没有修改过源文件直接修改
+                resContent = createBuffer(`${importStart+'\n'
+                    }@import url("./${externalFileName}?${nowDate}");${
+                    '\n'+importEnd}`+content);
+            }
+            return writeFileUri(uri, resContent);
+        }).then(() => {
+            resolve({ modify: true });
+        }).catch(err => {
+            if (err.jump) {
+                resolve({ modify: err.modify });
+            } else {
+                reject(err);
+            }
+        });
     });
 }
 
@@ -256,31 +254,32 @@ export function setSourceCssImportInfo (init: boolean = false) : Promise<{modify
  */
 export function checkCurentImageIsSame (codeValue: string): Promise<{ state:boolean, code?:string }> {
     return new Promise((resolve, reject) => {
-        try {
+        Promise.resolve(<Promise<void>>new Promise(resolve => {
             if (!codeValue) {
                 throw { jump: true, state: false };
+            } else {
+                resolve();
             }
-            getExternalFileContent().then(content => {
-                return findInfo(content[0]);
-            }).then(data => {
-                if (data) {
-                    const { ImageCode } = data;
-                    // 如果和上一次是一个哈希值，不再更新数据
-                    if (ImageCode === codeValue) {
-                        throw { jump: true, state: true, code: ImageCode };
-                    }
+        })).then(() => {
+            return getExternalFileContent();
+        }).then(content => {
+            return findInfo(content[0]);
+        }).then(data => {
+            if (data) {
+                const { ImageCode } = data;
+                // 如果和上一次是一个哈希值，不再更新数据
+                if (ImageCode === codeValue) {
+                    throw { jump: true, state: true, code: ImageCode };
                 }
-                resolve({ state: false, code: codeValue });
-            }).catch(err => {
-                if (err.jump) {
-                    resolve({ state: err.state, code: err.code??undefined });
-                } else {
-                    reject(err);
-                }
-            });
-        } catch (error) {
-            errHandle(error);
-        }
+            }
+            resolve({ state: false, code: codeValue });
+        }).catch(err => {
+            if (err.jump) {
+                resolve({ state: err.state, code: err.code??undefined });
+            } else {
+                reject(err);
+            }
+        });
     });
 }
 
@@ -336,38 +335,36 @@ function deleteConfiguration (): Promise<void> {
  */
 function getCssUri (name: string, create: boolean = true): Promise<Uri | void> {
     return new Promise((resolve, reject) => {
-        try {
-            if (name) {
-                const uri = Uri.file(join(dirname((require.main as NodeModule).filename), 'vs', 'workbench', name));
-                isFileExits(uri).then(res => {
-                    if (res) {
-                        // 有指定路径
-                        throw { jump: true, uri };
-                    } else {
-                        if (!create) {
-                            // 不创建文件，直接返回
-                            throw { jump: true };
-                        } else {
-                            return writeFileUri(uri, createBuffer(""));
-                        }
-                    }
-                }).then(() => {
-                    resolve(uri);
-                }).catch(err => {
-                    if (err.jump) {
-                        if (err.uri) {
-                            resolve(err.uri);
-                        } else {
-                            resolve();
-                        }
-                    } else {
-                        reject(err);
-                    }
-                });
-            }
-        } catch (error) {
-            errHandle(error);
+        if (!name) {
+            resolve();
+            return;
         }
+        const uri = Uri.file(join(dirname((require.main as NodeModule).filename), 'vs', 'workbench', name));
+        isFileExits(uri).then(res => {
+            if (res) {
+                // 有指定路径
+                throw { jump: true, uri };
+            } else {
+                if (!create) {
+                    // 不创建文件，直接返回
+                    throw { jump: true };
+                } else {
+                    return writeFileUri(uri, createBuffer(""));
+                }
+            }
+        }).then(() => {
+            resolve(uri);
+        }).catch(err => {
+            if (err.jump) {
+                if (err.uri) {
+                    resolve(err.uri);
+                } else {
+                    resolve();
+                }
+            } else {
+                reject(err);
+            }
+        });
     });
 }
 
@@ -378,19 +375,15 @@ function getCssUri (name: string, create: boolean = true): Promise<Uri | void> {
  */
 export function writeExternalCssFile (content: string): Promise<void> {
     return new Promise((resolve, reject) => {
-        try {
-            getCssUri(externalFileName).then(uri => {
-                if (uri) {
-                    return writeFileUri(uri, createBuffer(content));
-                }
-            }).then(() => {
-                resolve();
-            }).catch(err => {
-                reject(err);
-            });
-        } catch (error) {
-            errHandle(error);
-        }
+        getCssUri(externalFileName).then(uri => {
+            if (uri) {
+                return writeFileUri(uri, createBuffer(content));
+            }
+        }).then(() => {
+            resolve();
+        }).catch(err => {
+            reject(err);
+        });
     });
 }
 
@@ -400,20 +393,16 @@ export function writeExternalCssFile (content: string): Promise<void> {
  */
 export function getExternalFileContent (): Promise<[string, Uri]> {
     return new Promise((resolve, reject) => {
-        try {
-            let uriValue: Uri;
-            // 获取指定路径uri，没有文件则创建
-            getCssUri(externalFileName).then(uri => {
-                uriValue = uri!;
-                return readFileUri(uri!);
-            }).then(content => {
-                resolve([content.toString(), uriValue]);
-            }).catch(err => {
-                reject(err);
-            });
-        } catch (error) {
-            errHandle(error);
-        }
+        let uriValue: Uri;
+        // 获取指定路径uri，没有文件则创建
+        getCssUri(externalFileName).then(uri => {
+            uriValue = uri!;
+            return readFileUri(uri!);
+        }).then(content => {
+            resolve([content.toString(), uriValue]);
+        }).catch(err => {
+            reject(err);
+        });
     });
 }
 
@@ -424,66 +413,62 @@ export function getExternalFileContent (): Promise<[string, Uri]> {
  */
 function getExternalCssContent (codeValue: string): Promise<[string, info] | false> {
     return new Promise((resolve, reject) => {
-        try {
-            let imageUri: Uri;
-            const extensionVer = getVersion();
-            const date = getDate();
-            imageStoreUri().then(uri => {
-                if (!uri) {
-                    throw new Error('null uri');
+        let imageUri: Uri;
+        const extensionVer = getVersion(),
+        date = getDate();
+        imageStoreUri().then(uri => {
+            if (!uri) {
+                throw new Error('null uri');
+            }
+            imageUri = uri;
+            return getExternalFileContent();
+        }).then(content => {
+            return findInfo(content[0]);
+        }).then(data => {
+            if (data) {
+                const { ImageCode, VSCodeVersion, ExtensionVersion } = data;
+                // 如果和上一次是一个哈希值，并且vscode和插件版本号相同，不再更新数据
+                if (ImageCode === codeValue && VSCodeVersion === version && ExtensionVersion === extensionVer) {
+                    throw { jump: true, data: false };
                 }
-                imageUri = uri;
-                return getExternalFileContent();
-            }).then(content => {
-                return findInfo(content[0]);
-            }).then(data => {
-                if (data) {
-                    const { ImageCode, VSCodeVersion, ExtensionVersion } = data;
-                    // 如果和上一次是一个哈希值，并且vscode和插件版本号相同，不再更新数据
-                    if (ImageCode === codeValue && VSCodeVersion === version && ExtensionVersion === extensionVer) {
-                        throw { jump: true, data: false };
-                    }
+            }
+            return readFileUri(newUri(imageUri, `${codeValue}.back.wyg`));
+        }).then(image => {
+            const opacity = getNewBackgroundOpacity(backgroundImageConfiguration.getBackgroundOpacity());
+            const delay = 2; // 动画延迟的时间
+            resolve([
+                `${importStart+'\n'
+                }/**${'\n'
+                }* VSCodeVersion [ ${version} ]${'\n'
+                }* ExtensionVersion [ ${extensionVer} ]${'\n'
+                }* Date [ ${date} ]${'\n'
+                }* ImageCode [ ${codeValue} ]${'\n'
+                }*/${'\n'
+                }@keyframes vscode-body-hide-wyg{from{background-size:0;}to{background-size:0;}}${'\n'
+                }@keyframes vscode-body-opacity-wyg{from{opacity:1;}to{opacity:${opacity};}}${'\n'
+                }body {${'\n'
+                }   opacity: ${opacity};${'\n'
+                }   background-repeat: no-repeat;${'\n'
+                }   background-size: cover;${'\n'
+                }   background-position: center;${'\n'
+                }   animation: vscode-body-hide-wyg ${delay}s,vscode-body-opacity-wyg 2s ease ${delay}s;${'\n'
+                }   background-image: url('${image}');${'\n'
+                }}${
+                '\n'+importEnd}`,
+                {
+                    VSCodeVersion: version,
+                    ExtensionVersion: extensionVer,
+                    Date: date,
+                    ImageCode: codeValue
                 }
-                return readFileUri(newUri(imageUri, `${codeValue}.back.wyg`));
-            }).then(image => {
-                const opacity = getNewBackgroundOpacity(backgroundImageConfiguration.getBackgroundOpacity());
-                const delay = 2; // 动画延迟的时间
-                resolve([
-                    `${importStart+'\n'
-                    }/**${'\n'
-                    }* VSCodeVersion [ ${version} ]${'\n'
-                    }* ExtensionVersion [ ${extensionVer} ]${'\n'
-                    }* Date [ ${date} ]${'\n'
-                    }* ImageCode [ ${codeValue} ]${'\n'
-                    }*/${'\n'
-                    }@keyframes vscode-body-hide-wyg{from{background-size:0;}to{background-size:0;}}${'\n'
-                    }@keyframes vscode-body-opacity-wyg{from{opacity:1;}to{opacity:${opacity};}}${'\n'
-                    }body {${'\n'
-                    }   opacity: ${opacity};${'\n'
-                    }   background-repeat: no-repeat;${'\n'
-                    }   background-size: cover;${'\n'
-                    }   background-position: center;${'\n'
-                    }   animation: vscode-body-hide-wyg ${delay}s,vscode-body-opacity-wyg 2s ease ${delay}s;${'\n'
-                    }   background-image: url('${image}');${'\n'
-                    }}${
-                    '\n'+importEnd}`,
-                    {
-                        VSCodeVersion: version,
-                        ExtensionVersion: extensionVer,
-                        Date: date,
-                        ImageCode: codeValue
-                    }
-                ]);
-            }).catch(err => {
-                if (err.jump) {
-                    resolve(err.data);
-                } else {
-                    reject(err);
-                }
-            });
-        } catch (error) {
-            errHandle(error);
-        }
+            ]);
+        }).catch(err => {
+            if (err.jump) {
+                resolve(err.data);
+            } else {
+                reject(err);
+            }
+        });
     });
 }
 
@@ -493,7 +478,7 @@ function getExternalCssContent (codeValue: string): Promise<[string, info] | fal
  * @returns 
  */
 function getNowSettingCode (): Promise<string | false> {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
         try {
             const storageCode = backgroundImageConfiguration.getBackgroundNowImagePath();
             if (!storageCode) {
@@ -502,7 +487,7 @@ function getNowSettingCode (): Promise<string | false> {
                 resolve(storageCode);
             }
         } catch (error) {
-            errHandle(error);
+            reject(error);
         }
     });
 }
@@ -513,27 +498,23 @@ function getNowSettingCode (): Promise<string | false> {
  */
 function getSourceCssFileContent (): Promise<[string, Uri] | void> {
     return new Promise((resolve, reject) => {
-        try {
-            let uriValue: Uri;
-            getCssUri(cssName, false).then(uri => {
-                if (uri) {
-                    uriValue = uri;
-                    return readFileUri(uri);
-                } else {
-                    throw { jump: true };
-                }
-            }).then(res => {
-                resolve([res!.toString(), uriValue]);
-            }).catch(err => {
-                if (err.jump) {
-                    resolve();
-                } else {
-                    reject(err);
-                }
-            });
-        } catch (error) {
-            errHandle(error);
-        }
+        let uriValue: Uri;
+        getCssUri(cssName, false).then(uri => {
+            if (uri) {
+                uriValue = uri;
+                return readFileUri(uri);
+            } else {
+                throw { jump: true };
+            }
+        }).then(res => {
+            resolve([res!.toString(), uriValue]);
+        }).catch(err => {
+            if (err.jump) {
+                resolve();
+            } else {
+                reject(err);
+            }
+        });
     });
 }
 
@@ -545,7 +526,7 @@ function getSourceCssFileContent (): Promise<[string, Uri] | void> {
  * @returns 
  */
 function isSourceCssFileModify (content: string, uri: Uri): Promise<{ content:string, uri:Uri, exits:boolean }> {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
         try {
             const reg = content.match(findSourceCssPositionRegexp);
             // 有匹配项返回，exits字段为true
@@ -555,7 +536,7 @@ function isSourceCssFileModify (content: string, uri: Uri): Promise<{ content:st
                 resolve({ content, uri, exits: false })
             }
         } catch (error) {
-            errHandle(error);
+            reject(error);
         }
     });
 }
@@ -566,7 +547,7 @@ function isSourceCssFileModify (content: string, uri: Uri): Promise<{ content:st
  * @returns 
  */
 function findInfo (content: string): Promise<info | false> {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
         try {
             const reg = content.match(findExternalCssPositionRegexp);
             // 有匹配项返回信息
@@ -581,7 +562,7 @@ function findInfo (content: string): Promise<info | false> {
                 resolve(false);
             }
         } catch (error) {
-            errHandle(error);
+            reject(error);
         }
     });
 }

--- a/src/backgroundImage/modifyByInput.ts
+++ b/src/backgroundImage/modifyByInput.ts
@@ -36,22 +36,18 @@ export function requestImageToBackground (url: string) {
  */
 function getImageBase64ByRequest (url: string): Promise<string> {
     return new Promise((resolve, reject) => {
-        try {
-            const reg = url.match(imageUrl);
-            if (!reg) {
-                reject(new Error('Illegal Image URL'));
-                return;
-            }
-            GetImage(url).then(res => {
-                return base64ByFiletypeAndData('image', imageToBase64Type(reg[2]), res);
-            }).then(data => {
-                resolve(data);
-            }).catch(err => {
-                reject(err);
-            });
-        } catch (error) {
-            errHandle(error);
+        const reg = url.match(imageUrl);
+        if (!reg) {
+            reject(new Error('Illegal Image URL'));
+            return;
         }
+        GetImage(url).then(res => {
+            return base64ByFiletypeAndData('image', imageToBase64Type(reg[2]), res);
+        }).then(data => {
+            resolve(data);
+        }).catch(err => {
+            reject(err);
+        });
     });
 }
 
@@ -90,23 +86,19 @@ export function backgroundOpacityModify (opacity: number) {
  */
 function changeBackgroundFileOpacity (opacity: number): Promise<boolean> {
     return new Promise((resolve, reject) => {
-        try {
-            if (opacity === backgroundImageConfiguration.getBackgroundOpacity()) {
-                resolve(false);
-                return;
-            }
-            getExternalFileContent().then(data => {
-                const content = getExternalCssModifyOpacityContent(data[0], getNewBackgroundOpacity(opacity));
-                return writeExternalCssFile(content);
-            }).then(() => {
-                return setSourceCssImportInfo();
-            }).then(() => {
-                resolve(true);
-            }).catch(err => {
-                reject(err);
-            });
-        } catch (error) {
-            errHandle(error);
+        if (opacity === backgroundImageConfiguration.getBackgroundOpacity()) {
+            resolve(false);
+            return;
         }
+        getExternalFileContent().then(data => {
+            const content = getExternalCssModifyOpacityContent(data[0], getNewBackgroundOpacity(opacity));
+            return writeExternalCssFile(content);
+        }).then(() => {
+            return setSourceCssImportInfo();
+        }).then(() => {
+            resolve(true);
+        }).catch(err => {
+            reject(err);
+        });
     });
 }

--- a/src/backgroundImage/modifyRandom.ts
+++ b/src/backgroundImage/modifyRandom.ts
@@ -32,23 +32,23 @@ export function randomSettingBackground (value: string[] | false, tip: boolean =
     }
     isChangeBackgroundImage('是否设置背景图随机切换？每次打开软件会随机切换一张背景图。').then(() => {
         backgroundImageConfiguration.setBackgroundIsRandom(true)
-            .then(() => {
-                return backgroundImageConfiguration.setBackgroundRandomList(value);
-            }, err => {
-                errHandle(err);
-            }).then(() => {
-                setMessage({ message: '设置完成，下次打开软件会随机切换背景图。' });
-            }, err => {
-                errHandle(err);
-            }).then(() => {
-                // 发送设置的数据
-                backgroundSendMessage({
-                    name: 'backgroundRandomList',
-                    value
-                });
-                // 切换一张背景图，下次打开生效
-                setRandomBackground();
+        .then(() => {
+            return backgroundImageConfiguration.setBackgroundRandomList(value);
+        }, err => {
+            errHandle(err);
+        }).then(() => {
+            setMessage({ message: '设置完成，下次打开软件会随机切换背景图。' });
+        }, err => {
+            errHandle(err);
+        }).then(() => {
+            // 发送设置的数据
+            backgroundSendMessage({
+                name: 'backgroundRandomList',
+                value
             });
+            // 切换一张背景图，下次打开生效
+            setRandomBackground();
+        });
     }).catch(err => {
         errHandle(err);
     });

--- a/src/backgroundImage/regist.ts
+++ b/src/backgroundImage/regist.ts
@@ -48,7 +48,7 @@ function checkRandomCode (): Promise<void> {
 					resolve();
 				}, err => {
 					reject(err);
-				})
+				});
 			} else {
 				resolve();
 			}

--- a/src/backgroundImage/selectStore.ts
+++ b/src/backgroundImage/selectStore.ts
@@ -15,15 +15,13 @@ export function selectFolderForBackgroundStore (): void {
                 title: '确认'
             }]
         }).then(res => {
-            if (res) 
-                return selectFile({
-                    files: false,
-                    folders: true,
-                    title: '选择背景图储存文件夹'
-                });
+            if (res) return selectFile({
+                files: false,
+                folders: true,
+                title: '选择背景图储存文件夹'
+            });
         }).then(data => {
-            if (data) 
-                return resetImageStorePath(data.dirName);
+            if (data) return resetImageStorePath(data.dirName);
         }).catch(err => {
             errHandle(err, true);
         });
@@ -46,8 +44,7 @@ export function resetBackgroundStorePath (): void {
                 title: '确认'
             }]
         }).then(res => {
-            if (res) 
-                return resetImageStorePath('', true);
+            if (res) return resetImageStorePath('', true);
         }).catch(err => {
             errHandle(err, true);
         });

--- a/src/backgroundImage/utils.ts
+++ b/src/backgroundImage/utils.ts
@@ -73,6 +73,11 @@ export function imageStoreUriExits (uri: Uri): Promise<Uri> {
  * @param reset 是否重置路径
  */
 export async function resetImageStorePath (path: string, reset: boolean = false): Promise<void> {
+    // 将储存数组数据重置为空
+    await backgroundImageConfiguration.refreshBackgroundImagePath([])
+        .then(() => {}, err => {
+            return Promise.reject(err);
+        })
     if (reset) {
         if (!backgroundImageConfiguration.getBackgroundStorePath()) {
             setMessage({
@@ -81,11 +86,6 @@ export async function resetImageStorePath (path: string, reset: boolean = false)
             return Promise.resolve();
         }
         await backgroundImageConfiguration.setBackgroundStorePath("")
-            .then(() => {}, err => {
-                return Promise.reject(err);
-            });
-        // 将缓存数组数据重置为空
-        await backgroundImageConfiguration.refreshBackgroundImagePath([])
             .then(() => {}, err => {
                 return Promise.reject(err);
             });
@@ -99,11 +99,6 @@ export async function resetImageStorePath (path: string, reset: boolean = false)
     if (path && uri) {
         // 缓存数据
         await backgroundImageConfiguration.setBackgroundStorePath(uri.fsPath)
-            .then(() => {}, err => {
-                return Promise.reject(err);
-            });
-        // 将缓存数组数据重置为空
-        await backgroundImageConfiguration.refreshBackgroundImagePath([])
             .then(() => {}, err => {
                 return Promise.reject(err);
             });

--- a/src/backgroundImage/utils.ts
+++ b/src/backgroundImage/utils.ts
@@ -84,6 +84,11 @@ export async function resetImageStorePath (path: string, reset: boolean = false)
             .then(() => {}, err => {
                 return Promise.reject(err);
             });
+        // 将缓存数组数据重置为空
+        await backgroundImageConfiguration.refreshBackgroundImagePath([])
+            .then(() => {}, err => {
+                return Promise.reject(err);
+            });
         setMessage({
             message: '背景图储存路径已切换为默认路径'
         });
@@ -94,6 +99,11 @@ export async function resetImageStorePath (path: string, reset: boolean = false)
     if (path && uri) {
         // 缓存数据
         await backgroundImageConfiguration.setBackgroundStorePath(uri.fsPath)
+            .then(() => {}, err => {
+                return Promise.reject(err);
+            });
+        // 将缓存数组数据重置为空
+        await backgroundImageConfiguration.refreshBackgroundImagePath([])
             .then(() => {}, err => {
                 return Promise.reject(err);
             });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
+import type { ExtensionContext } from 'vscode';
 import { registBackground } from './backgroundImage/regist';
 import { contextContainer } from './utils/webview/index';
 
-export function activate(context: vscode.ExtensionContext) {
+export function activate(context: ExtensionContext) {
 	contextContainer.instance = context;
 
 	// 注册背景图侧栏页面
@@ -10,4 +10,6 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() { }
+export function deactivate() {
+	contextContainer.instance = undefined;
+}

--- a/src/filePackage/check.ts
+++ b/src/filePackage/check.ts
@@ -11,7 +11,7 @@ if (!process.env.NODE_ENV) {
             exu.push(check_ver(item, n_v));
         });
         Promise.all(exu).then(() => {
-            console.log(consoleByColor('green', '\n打包状态及版本校验完成\n'));
+            console.log(consoleByColor('green', `\n打包状态及版本校验完成  （当前版本：v${n_v}）\n`));
         }).catch(err => {
             ProcessExit(consoleByColor('red', err) + consoleByColor('yellow', '\n请执行npm run pre或者通过调试启动Run Pre'), 1);
         });
@@ -26,7 +26,7 @@ function check_ver (file_path: string, n_v: string): Promise<string> {
         getContent(file_path).then(res => {
             let l_v = latest_ver(res);
             if (!l_v || l_v !== n_v) {
-                reject(file_path + ' ---> 版本错误');
+                reject(file_path + ' ---> 版本错误    ' + `预发布版本：v${n_v}；文件打包版本：${l_v?'v'+l_v:'不存在'}`);
             } else {
                 resolve(file_path);
             }

--- a/src/utils/interactive/index.ts
+++ b/src/utils/interactive/index.ts
@@ -175,6 +175,18 @@ export function setStatusBar (message: string | StatusBarIconMessage, option?:St
 }
 
 /**
+ * 通过dispose手动关闭statusBar的方法
+ * @param message 
+ * @returns 
+ */
+export function setStatusBarResolve (message: string | StatusBarIconMessage): Disposable {
+    if (isObject(message)) {
+        message = `$(${message.icon})${message.message}`;
+    }
+    return window.setStatusBarMessage(message);
+}
+
+/**
  * 调用进度条api
  * @param options 
  * @param task 

--- a/src/utils/viewImage/index.ts
+++ b/src/utils/viewImage/index.ts
@@ -16,6 +16,7 @@ var webviewTarget: Webview | null = null;
  * @param title 标题
  */
 export function toViewImage (path: string, title: string, useWebView: Webview) {
+    if (!path) return;
     if (!viewImageWebviewInstance) {
         viewImageWebviewInstance = registerWebviewPanel('ViewImage', { path: 'webview/src/viewImage', title: 'image:'+title });
         viewImageWebviewInstance.onDidDispose(destroyInstance);

--- a/src/utils/webview/index.ts
+++ b/src/utils/webview/index.ts
@@ -79,7 +79,7 @@ export class FileMerge {
                 this.htmlContent = this.htmlContent
                 .replace(/(#policy)/, 
                     `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src ${webview.cspSource}; style-src ${
-                    webview.cspSource}; script-src 'nonce-${nonce}'; img-src ${webview.cspSource} https: data:;">`
+                    webview.cspSource}; script-src 'nonce-${nonce}'; img-src ${webview.cspSource} https: data: blob:;">`
                 )
                 .replace(/(#css)/, this.newCssUri?
                     `<link href="${webview.asWebviewUri(this.newCssUri)}" rel="stylesheet />`:

--- a/src/workspace/background.ts
+++ b/src/workspace/background.ts
@@ -3,6 +3,9 @@ import { isString } from "../utils";
 
 const namespace = 'wangyige.background';
 
+/**
+ * 背景图配置项对象
+ */
 export const backgroundImageConfiguration = {
     /**
      * 获取背景图配置信息

--- a/webview/reset.css
+++ b/webview/reset.css
@@ -1,3 +1,5 @@
+/* index(0) */
+
 html {
 	box-sizing: border-box;
 	font-size: 10px;

--- a/webview/src/background/css/animation.css
+++ b/webview/src/background/css/animation.css
@@ -44,6 +44,26 @@
 	}
 }
 
+/* 线条过渡动画 */
+@keyframes loading-gradient {
+	from {
+		background-position: 100% 50%;
+	}
+	to {
+		background-position: 0 50%;
+	}
+}
+
+/* 模糊过渡动画 */
+@keyframes blur-transition {
+	from {
+		filter: blur(var(--blur-number));
+	}
+	to {
+		filter: blur(0);
+	}
+}
+
 .loading-rotate {
 	animation: loading-rotate 1.5s ease infinite;
 }

--- a/webview/src/background/css/style.css
+++ b/webview/src/background/css/style.css
@@ -119,6 +119,7 @@ nav.list > img {
 
 /* 图片列表容器 */
 div.image-container {
+	--blur-number: 5px;
     width: 95%;
 	max-width: 333px;
     border-radius: 5px;
@@ -134,7 +135,7 @@ div.image-container {
 
 div.image-container.image-delete {
 	opacity: 0;
-	animation: image-delete .5s ease;
+	animation: image-delete .5s cubic-bezier(0.5, 0, 0.5, 1);
 }
 
 div.image-container:hover {
@@ -157,11 +158,71 @@ div.image-container:not(:last-child) {
 	margin-bottom: 10px;
 }
 
-div.image-container > img.image {
+/* 新插入的图片添加一个展开动画 */
+div.image-container[init=false] {
+	animation: image-add .5s cubic-bezier(0.5, 0, 0.5, 1);
+}
+
+/* 图片遮罩容器 */
+div.image-container > div.image-popup {
+	display: inline-block;
+	user-select: none;
+	width: 90%;
+	height: auto;
+	line-height: 1em;
+	border-radius: 5px;
+	position: relative;
+	text-align: center;
+}
+
+div.image-container[loaded=false] > div.image-popup {
+	pointer-events: none;
+	aspect-ratio: 1.7;
+}
+
+div.image-container[loaded=false] > div.image-popup.loading-gradient > * {
+	display: none!important;
+}
+
+/* 线性加载动画样式 */
+div.image-container[loaded=false] > div.image-popup.loading-gradient {
+	background: linear-gradient(90deg, #f2f2f2 25%, #c7c7c7 37%, #f2f2f2 63%);
+	background-size: 400% 100%;
+}
+
+/* 新增图片需要等展开动画完成再开始线性加载动画 */
+div.image-container[init=false][loaded=false] > div.image-popup.loading-gradient {
+	animation: loading-gradient 1.5s ease .5s infinite;
+}
+
+/* 新增图片需要等展开动画完成再开始线性加载动画 */
+div.image-container[init=true][loaded=false] > div.image-popup.loading-gradient {
+	animation: loading-gradient 1.5s ease infinite;
+}
+
+/* 图片 */
+div.image-container > div.image-popup > img.image {
 	user-select: none;
 	max-width: 90%;
 	max-height: 150px;
-	animation: image-add .5s ease;
+	position: relative;
+	transition: opacity .3s ease;
+}
+
+/* 图片未完成加载时的透明度 */
+div.image-container[loaded=false] > div.image-popup > img.image {
+	opacity: 0;
+}
+
+/* 图片加载完成时的透明度 */
+div.image-container[loaded=true] > div.image-popup > img.image {
+	opacity: 1;
+}
+
+/* 加载完成，图片遮罩过渡关闭 */
+div.image-container[loaded=true] > div.image-popup {
+	background: transparent;
+	animation: blur-transition .5s ease;
 }
 
 /* 图片操作 */

--- a/webview/src/background/js/image.js
+++ b/webview/src/background/js/image.js
@@ -58,7 +58,7 @@ function createInstance () {
             /** @type {string} */
             this.id = listId;
             /** @type {HTMLElement} */
-            this.element = getId(this.id);
+            this.element = $query('#'+this.id);
             // 劫持选择列表长度改变
             this.#resetSelectImageList(this);
             // 代理数组双向绑定
@@ -156,10 +156,8 @@ function createInstance () {
                         _this.renderBySelectListLength(false);
                     }
                     if (property === 'length') {
-                        // 判断是否需要展示删除按钮
-                        const batchButton = $query(
-                            `.${batchButtonContainerClass}`
-                        );
+                        /** @type {HTMLElement} 判断是否需要展示删除按钮 */
+                        const batchButton = $query(`.${batchButtonContainerClass}`);
                         if (value > 0) {
                             batchButton.classList.add(selectButtonToContainerClass);
                         } else {
@@ -220,10 +218,8 @@ function createInstance () {
          * 根据当前是否已经设置随机切换和勾选的图片数量进行按钮内文字的替换
          */
         settingRandomButtonText () {
-            // 切换按钮内文字
-            const buttonItem = $query(
-                `.${batchButtonContainerClass} #${randomBackId}`
-            );
+            /** @type {HTMLElement|null} 切换按钮内文字 */
+            const buttonItem = $query(`.${batchButtonContainerClass} #${randomBackId}`);
             if (!buttonItem) 
                 return;
             const length = this.selectImageList.length;
@@ -261,17 +257,17 @@ function createInstance () {
             const { src, code } = data;
             if (!src) return;
             /** 外层容器 @type {HTMLElement} */
-            let el = createELement('div', { 
+            let el = complexSetAttr($create('div'), { 
                 class: `${listImageClass} ${this.settingRandomButtonTextState === 1 ? imageIsRandomClass : ''}`, 
                 [imageContainerCodeName]: code, 
                 id: imageContainerCode+'-'+code 
             });
             // 图片本体
-            el.appendChild(createELement('img', { class: imageClass, loading: 'lazy', title: '右键查看大图', src }));
+            el.appendChild(complexSetAttr($create('img'), { class: imageClass, loading: 'lazy', title: '右键查看大图', src }));
             // 操作按钮
             let selectBut, deleteBut;
-            el.appendChild(selectBut = createELement('span', { class: imageButtonClass }));
-            el.appendChild(deleteBut = createELement('span', { class: imageButtonClass }));
+            el.appendChild(selectBut = complexSetAttr($create('span'), { class: imageButtonClass }));
+            el.appendChild(deleteBut = complexSetAttr($create('span'), { class: imageButtonClass }));
             classListOperation(selectBut, 'add', imageSelectButtonClass, circleBackIconClass);
             classListOperation(deleteBut, 'add', imageDeleteButtonClass, deleteIconClass);
             // 事件绑定
@@ -306,16 +302,13 @@ function createInstance () {
             if (!target) return;
             // 添加删除类名动画
             classListOperation(target, 'add', imageDeleteCLass);
-            const selectBut = target.querySelector(
-                `.${imageButtonClass}.${imageSelectButtonClass}`
-            );
-            const deleteBut = target.querySelector(
-                `.${imageButtonClass}.${imageDeleteButtonClass}`
-            );
+            let selectBut = $query(`.${imageButtonClass}.${imageSelectButtonClass}`, target),
+                deleteBut = $query(`.${imageButtonClass}.${imageDeleteButtonClass}`, target);
             // 解除事件绑定
             this.imageSelectIconEventBind(selectBut, true);
             this.imageDeleteIconEventBind(deleteBut, true);
             this.imageElementEventBind(target, true);
+            selectBut = null, deleteBut = null;
             setTimeout(() => {
                 target.remove();
             }, imageAnimationTime);
@@ -337,7 +330,9 @@ function createInstance () {
                 // 设置传入的数据
                 this.deleteAllRandomSelectClass();
                 array.forEach(item => {
-                    $query(`.${listImageClass}#${imageContainerCode}-${item}`)?.classList.add(imageIsRandomClass);
+                    /** @type {HTMLElement} */
+                    const result = $query(`.${listImageClass}#${imageContainerCode}-${item}`);
+                    result?.classList.add(imageIsRandomClass);
                 });
             }
         }
@@ -362,6 +357,7 @@ function createInstance () {
                 this.imageInfoLoading = loading;
                 // 加载状态不同，empty属性相同也可能有不同语句，需要重置状态
                 this.imageInfoEmpty = undefined;
+                /** @type {HTMLElement} */
                 let loadingTarget = $query(imageListInfoIcon);
                 if (loading) {
                     // 添加动画
@@ -374,6 +370,7 @@ function createInstance () {
             }
             if (empty !== this.imageInfoEmpty) {
                 this.imageInfoEmpty = empty;
+                /** @type {HTMLElement} */
                 let infoTarget = $query(imageListInfoContent);
                 let containerTarget = getId(imageListInfoId);
                 if (empty) {
@@ -392,17 +389,16 @@ function createInstance () {
          * 检查是否有元素
          */
         check () {
-            if (!this.element) {
-                throw new Error('没有对应元素');
-            }
+            if (!this.element) throw new Error('没有对应元素');
         }
 
         /**
          * 获取子元素所有节点
+         * @returns {Element[]}
          */
         getChild () {
             this.check();
-            return this.element.querySelectorAll('.'+listImageClass);
+            return $query('.'+listImageClass, { all: true, element: this.element });
         }
 
         /**
@@ -423,13 +419,11 @@ function createInstance () {
             if (codes.length <= 0) 
                 return;
             codes.forEach(code => {
-                const target = $query( 
-                    `.${listImageClass}#${imageContainerCode}-${code}`
-                );
-                const classList = $query( 
-                    `.${imageButtonClass}.${imageSelectButtonClass}`,
-                    target
-                )?.classList;
+                /** @type {HTMLElement} */
+                const target = $query(`.${listImageClass}#${imageContainerCode}-${code}`),
+                /** @type {Element} */
+                childTarget = $query(`.${imageButtonClass}.${imageSelectButtonClass}`, target),
+                classList = childTarget?.classList;
                 if (!classList) 
                     return;
                 if (operation === 'add' && !classList.contains(ImageSelectStateClass)) {

--- a/webview/src/background/js/image.js
+++ b/webview/src/background/js/image.js
@@ -362,10 +362,10 @@ function createInstance () {
                 if (loading) {
                     // 添加动画
                     classListOperation(loadingTarget, 'add', loadingClass, imageListInfoShowClass);
-                    setHtmlText(loadingTarget, 'html', iconCode.loadingSingle);
+                    complexSetAttr(loadingTarget, iconCode.loadingSingle, 'html');
                 } else {
                     classListOperation(loadingTarget, 'remove', loadingClass, imageListInfoShowClass);
-                    setHtmlText(loadingTarget, 'html', '');
+                    complexSetAttr(loadingTarget, '', 'html');
                 }
             }
             if (empty !== this.imageInfoEmpty) {
@@ -376,11 +376,11 @@ function createInstance () {
                 if (empty) {
                     // 数组为空，根据加载情况显示文字
                     classListOperation(containerTarget, 'add', imageListInfoShowClass)
-                    setHtmlText(infoTarget, 'text', loading ? imageListInfoEmptyLoading : imageListInfoEmpty);
+                    complexSetAttr(infoTarget, loading ? imageListInfoEmptyLoading : imageListInfoEmpty, 'text');
                 } else {
                     // 数组不为空，隐藏文字区域
                     classListOperation(containerTarget, 'remove', imageListInfoShowClass);
-                    setHtmlText(infoTarget, 'text', '');
+                    complexSetAttr(infoTarget, '', 'text');
                 }
             }
         }

--- a/webview/src/background/js/image.js
+++ b/webview/src/background/js/image.js
@@ -464,6 +464,8 @@ function createInstance () {
             selectBut = null, deleteBut = null;
             setTimeout(() => {
                 target.remove();
+                // 开始检测懒加载元素
+                this.#scrollDebounce();
             }, imageAnimationTime);
         }
 

--- a/webview/src/background/js/index.js
+++ b/webview/src/background/js/index.js
@@ -6,7 +6,7 @@
 const vscode = acquireVsCodeApi();
 
 /** 当前选择查看的图片 @type {string|null} */
-var nowSelectViewImage = null;
+let nowSelectViewImage = null;
 
 const selectButtonId = 'selectImage'; // 选择图片的按钮
 const selectButtonText = '选择本地图片';

--- a/webview/src/background/js/index.js
+++ b/webview/src/background/js/index.js
@@ -401,8 +401,9 @@ function delayAddImage (array, callback=undefined) {
             if (status === 'fulfilled') {
                 // 加载成功的图片数据传参给延迟执行的函数并且插入数组执行
                 imageArray.push(voidDelay.bind(null, () => {
+                    let blobUrl = base64ToBlob(array[value][0]);
                     publicData.imageRenderList?.unshift({
-                        src: array[value][0],
+                        src: blobUrl,
                         code: array[value][1]
                     });
                 }));

--- a/webview/src/background/js/index.js
+++ b/webview/src/background/js/index.js
@@ -605,18 +605,3 @@ function objectHas (object, ...property) {
     }
     return result;
 }
-
-/**
- * 设置innerHTML和innerText
- * @param {HTMLElement} target 
- * @param {'html'|'text'} type 
- * @param {string} content 
- */
-function setHtmlText (target, type, content) {
-    if (!target) return;
-    if (type === 'html') {
-        target.innerHTML = content;
-    } else if (type === 'text') {
-        target.innerText = content;
-    }
-}

--- a/webview/src/background/js/index.js
+++ b/webview/src/background/js/index.js
@@ -101,16 +101,16 @@ window.addEventListener('load', onDataLoad.bind(this, false));
 getId(selectButtonId)?.addEventListener('click', buttonClickSelectImage);
 
 // 批量删除按钮绑定事件
-getId(batchDeleteId)?.addEventListener('click', buttonClickDeleteSelect);
+getId(batchDeleteId)?.addEventListener('click', canChangeForButton.bind(this, buttonClickDeleteSelect));
 
 // 批量随机设置背景图事件
-getId(randomBackId)?.addEventListener('click', buttonClickRandomBackground);
+getId(randomBackId)?.addEventListener('click', canChangeForButton.bind(this, buttonClickRandomBackground));
 
 // 全选按钮点击事件
-getId(selectAllId)?.addEventListener('click', buttonClickSelectAll);
+getId(selectAllId)?.addEventListener('click', canChangeForButton.bind(this, buttonClickSelectAll));
 
 // 取消全选按钮点击事件
-getId(selectCancelId)?.addEventListener('click', buttonClickSelectCancel);
+getId(selectCancelId)?.addEventListener('click', canChangeForButton.bind(this, buttonClickSelectCancel));
 
 // 脚本侧通信接收事件
 window.addEventListener('message', receiveMessage);
@@ -244,6 +244,13 @@ function buttonClickSelectImage () {
         name: 'selectImage',
         value: true
     });
+}
+
+/**
+ * 根据能否点击变量判断是否触发函数
+ */
+function canChangeForButton (callback) {
+    if (canChange()) callback?.();
 }
 
 /**
@@ -500,32 +507,6 @@ function changeRenderByRandomSetting (data) {
 }
 
 /**
- * 创建标签元素
- * @param {string} name 标签名
- * @param {object} option 属性
- * @returns {HTMLElement}
- */
-function createELement (name, options={}) {
-    const el = document.createElement(name);
-    setAllAttribute(el, options);
-    return el;
-}
-
-/**
- * 批量设置元素属性
- * @param {HTMLElement} el 
- * @param {Object} options 
- */
-function setAllAttribute (el, options={}) {
-    Object.keys(options).forEach(item => {
-        let i = options[item];
-        Array.isArray(i) ? 
-            el.setAttribute(item, i.join(' ')) : 
-            el.setAttribute(item, i);
-    });
-}
-
-/**
  * 通过id获取元素
  * @param {string} id 
  * @returns {HTMLElement}
@@ -533,17 +514,6 @@ function setAllAttribute (el, options={}) {
 function getId (id) {
     if (id) {
         return document.getElementById(id);
-    }
-}
-
-/**
- * 通过querySelector获取元素
- * @param {string} value 
- * @returns {HTMLElement}
- */
-function $query (value, target=document) {
-    if (value && target) {
-        return target.querySelector(value);
     }
 }
 

--- a/webview/src/background/js/input.js
+++ b/webview/src/background/js/input.js
@@ -65,7 +65,7 @@ function createInputEvent () {
                 if (newValue !== type && newValue < inputInfo.inputPlaceholder.length) {
                     type = newValue;
                     this.value = "";
-                    setAllAttribute(inputTarget, {
+                    complexSetAttr(inputTarget, {
                         placeholder: inputInfo.inputPlaceholder[type] + (type === 1 ? publicData.backgroundOpacity : ''),
                         'data-type': inputInfo.inputType[type]
                     });
@@ -83,10 +83,8 @@ function createInputEvent () {
             set (newValue) {
                 // 输入框只限制text类型，数字校验手动进行，数字类型输入框删除加减按钮失败
                 if (typeof newValue === 'string') {
-                    if (newValue && typeof this.type === 'number' && 
-                    inputInfo.inputType[this.type] === 'number' && 
-                    (!newValue.match(/^(?!\.)/) || 
-                    (newValue.match(/\./g) && newValue.match(/\./g).length > 1))) {
+                    if (newValue && isNumber(this.type) && inputInfo.inputType[this.type] === 'number' 
+                    && (!newValue.match(/^(?!\.)/) || (newValue.match(/\./g) && newValue.match(/\./g).length > 1))) {
                         // 数字校验，number类型转换float类型后不能为NaN，小数点不能出现在开头并且不能出现两个以上
                         value = isNaN(parseFloat(newValue)) ? value : String(parseFloat(newValue));
                     } else {
@@ -157,13 +155,20 @@ function createInputEvent () {
  */
 function createInputSelection (target) {
     inputInfo.selectionIcon.forEach(item => {
-        let element = createELement('span', {
-            title: item.title??'',
-            class: 'iconfont'
-        });
-        element.innerHTML = item.icon??'';
-        target.appendChild(element);
-        element = null;
+        // 插入元素
+        complexAppendChild(
+            target,
+            // 插入图标的innerHTML
+            complexSetAttr(
+                // 新创建元素并设置属性
+                complexSetAttr($create('span'), {
+                    title: item.title??'',
+                    class: 'iconfont'
+                }),
+                item.icon??'',
+                'html'
+            )
+        );
     });
 }
 
@@ -327,7 +332,7 @@ function opacityMessageGetHandle (opacity) {
     inputSendDataComplete();
     if (inputDataWatcher.type === 1) {
         // 修改输入框占位字符内容
-        setAllAttribute(getId(inputInfo.id), {
+        complexSetAttr(getId(inputInfo.id), {
             placeholder: inputInfo.inputPlaceholder[inputDataWatcher.type] + publicData.backgroundOpacity
         });
     }

--- a/webview/src/background/js/input.js
+++ b/webview/src/background/js/input.js
@@ -40,22 +40,25 @@ const inputDataWatcher = createInputEvent();
 registLock('inputConfirm', inputConfirmButtonLock);
 
 function createInputEvent () {
-    createInputSelection(document.querySelector(inputInfo.selectionContainer));
-    // 输入框类型控制按钮列表
-    const selection = document.querySelectorAll(inputInfo.selection);
-    // 输入框操作按钮
-    let operation = document.querySelectorAll(inputInfo.operation);
-    // 输入框操作按钮容器
-    let operationContainer = document.querySelector(inputInfo.operationContainer);
-    // 输入框的外层盒子
+    createInputSelection($query(inputInfo.selectionContainer));
+    /** @type {HTMLElement[]} 输入框类型控制按钮列表 */
+    const selection = $query(inputInfo.selection, true);
+    /** @type {HTMLElement[]} 输入框操作按钮 */
+    let operation = $query(inputInfo.operation, true);
+    /** @type {HTMLElement} 输入框操作按钮容器 */
+    let operationContainer = $query(inputInfo.operationContainer);
+    /** @type {HTMLElement} 输入框的外层盒子 */
     const box = getId(inputInfo.box);
-    // 输入框对象
+    /** @type {HTMLInputElement} 输入框对象 */
     const inputTarget = getId(inputInfo.id);
-    // 确认按钮
+    /** @type {HTMLElement} 确认按钮 */
     let confirm = getId(inputInfo.confirm);
-    // 清除按钮
+    /** @type {HTMLElement} 清除按钮 */
     let clear = getId(inputInfo.clear);
     let type = undefined, value = '';
+    /**
+     * @type {{type:number,value:string}}
+     */
     let inputDataWatcher = Object.defineProperties({}, {
         type: {
             // 0是下载外部图片；1是修改透明度
@@ -90,6 +93,7 @@ function createInputEvent () {
                     } else {
                         value = newValue;
                     }
+                    value = String(value);
                     inputStartCheck(this.type, value);
                     inputTarget.value = value;
                 }
@@ -280,7 +284,7 @@ function setBackgroundOpacity (opacity) {
 
 /**
  * 修改元素列表的类名
- * @param {NodeListOf<Element>} ellist 
+ * @param {Element[]} ellist 
  * @param {number} index 
  */
 function inputSelectionClass (ellist, index) {

--- a/webview/src/viewImage/js/index.js
+++ b/webview/src/viewImage/js/index.js
@@ -81,16 +81,6 @@ window.addEventListener('message', receiveMessage);
 // 双击复原图片
 document.body.addEventListener('dblclick', image_transform_reset);
 
-function debounce (callback, param) {
-    let timeout;
-    return function () {
-        if (timeout) {
-            clearTimeout(timeout);
-        }
-        timeout = setTimeout(callback.bind(null, param), 300);
-    }
-}
-
 /** 接收extensions侧发送的消息 */
 function receiveMessage ({ data }) {
     if (data.group !== 'viewImage') return;

--- a/webview/utils.js
+++ b/webview/utils.js
@@ -3,9 +3,63 @@
 /* 公共js工具 */
 
 /**
+ * 
+ * @param {string} type 
+ */
+function checkMediaType (type) {
+    const typeList = ['application', 'audio', 'font', 'example', 'image', 'message', 'model', 'multipart', 'text', 'video'];
+    for (let index in typeList) {
+        if (type.startsWith(typeList[index])) return true;
+    }
+    return false;
+}
+
+/**
  * 数据转换为blob
 */
-function dataToBlob (data, type) {}
+function dataToBlob (data, type) {
+    try {
+        if (!checkMediaType(type)) throw new Error('Illegal type');
+        return URL.createObjectURL(
+            new Blob(isArray(data)?data:[data], { type })
+        );
+    } catch (error) {
+        throw new Error(error);
+    }
+}
+
+/**
+ * 释放创建的URL对象
+ * @param {string} data 
+ */
+function revokeBlobData (data) {
+    try {
+        if (data) URL.revokeObjectURL(data);
+    } catch (error) {
+        throw new Error(error);
+    }
+}
+
+/**
+ * 获取base64数据的类型
+ * @param {string} data
+ */
+function getBase64Type (data) {
+    return data.match(/^data:(\w+)\/(\w+);base64,(.*?)$/);
+}
+
+function base64ToBlob (data) {
+    const result = getBase64Type(data);
+    const [n, dataName, fileName, fileData] = result;
+    console.log(fileData);
+    const butr = atob(fileData);
+    let length = butr.length;
+    const unit8 = new Uint8Array(length);
+    while (length--) {
+        unit8[length] = butr.charCodeAt(length);
+    }
+    return dataToBlob(unit8, `${dataName}/${fileName}`);
+}
 
 /**
  * 防抖函数

--- a/webview/utils.js
+++ b/webview/utils.js
@@ -39,7 +39,7 @@ function $create (name) {
  * @returns {string[] | {[key: string]: string}}
  */
 function complexGetAttr (target, options, list = true) {
-    if (!Array.isArray(options)) options = [];
+    if (!isArray(options)) options = [];
     if (!target || !target instanceof HTMLElement) return list ? new Array(options.length).fill(undefined) : options.reduce((obj, value) => {
         obj[value] = undefined;
         return obj;
@@ -57,21 +57,36 @@ function complexGetAttr (target, options, list = true) {
 /**
  * 设置复数节点属性
  * @param {HTMLElement} target 
- * @param {{[key: string]: string}|string} options
- * @param {'css'|'cssProperty'|'text'} type css: 设置css属性; cssProperty：设置css变量；text：设置文本
+ * @param {{[key: string]: string|string[]}|string} options
+ * @param {'css'|'cssProperty'|'text'|'html'} type css: 设置css属性; cssProperty：设置css变量；text：设置文本；html：innerHTML
  * @returns {HTMLElement}
  */
 function complexSetAttr (target, options, type) {
     if (!target || !target instanceof HTMLElement) return;
-    if (type === 'text' && typeof options === 'string') {
-        // 设置文本
-        target.innerText = options;
-        return target;
+    if (isString(options)) {
+        if (type === 'text') {
+            // 设置文本
+            target.innerText = options;
+            return target;
+        } else if (type === 'html') {
+            target.innerHTML = options;
+            return target;
+        }
     }
-    if (!toString.call(options) === '[object Object]') return target;
+    if (!isObject(options)) return target;
     for (let key in options) {
         if (!key) continue;
         let value = options[key];
+        // 如果属性有style，走css属性
+        if (key === 'style' && isObject(value)) {
+            complexSetAttr(target, value, 'css');
+            continue;
+        }
+        if (isArray(value)) value = value.reduce((pre, curr) => {
+            return pre + (isString(curr) ? curr : '');
+        }, '');
+        // 如果不是字符串，则以下操作直接跳过
+        if (!value || !isString(value)) continue;
         if (type === 'css') {
             // 设置css样式
             target.style.hasOwnProperty(key) ? target.style[key] = value : null;
@@ -89,14 +104,14 @@ function complexSetAttr (target, options, type) {
 
 /**
  * 将复数节点插入根节点
- * @param {HTMLElement|ShadowRoot} target dom节点或者阴影根节点
- * @param {HTMLElement[]} list 
- * @returns {HTMLElement}
+ * @param {Element|ShadowRoot} target dom节点或者阴影根节点
+ * @param {Element[]} list 
+ * @returns {Element}
  */
 function complexAppendChild (target, list) {
-    if (!target || !target instanceof HTMLElement || !target instanceof ShadowRoot) return;
+    if (!target || !target instanceof Element || !target instanceof ShadowRoot) return;
     if (!Array.isArray(list)) {
-        if (list && list instanceof HTMLElement) {
+        if (list && list instanceof Element) {
             list = [list];
         } else {
             return target
@@ -104,8 +119,108 @@ function complexAppendChild (target, list) {
     };
     for (let i = 0; i < list.length; i++) {
         let dom = list[i];
-        if (!dom || !dom instanceof HTMLElement) continue;
+        if (!dom || !dom instanceof Element) continue;
         target.appendChild(dom);
     }
     return target;
+}
+
+/**
+ * 选择元素节点
+ * @param {string} target
+ * @param {boolean|Element|{ all: boolean, element: Element }} options 传入boolean时，为是否获取所有元素；
+ * 为对象时，通过all属性设置获取所有元素，通过element属性设置检索对象
+ * @returns {Element|Element[]|null}
+ */
+function $query (target, options = false) {
+    if (!isString(target)) return null;
+    target = target.trim();
+    let all = false;
+    /** @type {Element} */
+    let element = document;
+    if (options instanceof Element) {
+        element = options;
+    } else if (isBoolean(options)) {
+        all = options;
+    } else if (isObject(options)) {
+        // 是否全选
+        all = options?.all??false;
+        // 检索对象
+        element = options?.element??document;
+    }
+    if (/^[^\s>~,:\.#]+[\s>~,:\.#]+/.test(target)) {
+        return all ? changeToArray(element.querySelectorAll(target)) : element.querySelector(target);
+    } else if (target.startsWith('.')) {
+        // 类名选择器
+        return all ? changeToArray(element.getElementsByClassName(target.slice(1))) : element.querySelector(target);
+    } else if (target.startsWith('#')) {
+        // 类名选择器
+        return document.getElementById(target.slice(1));
+    } else {
+        // 标签选择器
+        return all ? changeToArray(element.getElementsByTagName(target)) : element.querySelector(target);
+    }
+}
+
+/**
+ * 将元素对象转换为数组
+ * @typedef {Element} theElement
+ * @param {HTMLCollectionOf<theElement>|NodeListOf<theElement>|null} item 
+ * @returns {theElement[]}
+ */
+function changeToArray (item) {
+    if (!item) return item;
+    const result = [];
+    for (let i = 0; i < item.length; i++) {
+        result.push(item[i]);
+    }
+    return result;
+}
+
+/**
+ * 是否是字符串
+ * @param {any} target 
+ */
+function isString (target) {
+    return typeof target === 'string';
+}
+
+/**
+ * 是否是数组
+ * @param {any} target 
+ */
+function isArray (target) {
+    return Array.isArray(target);
+}
+
+/**
+ * 是否是对象
+ * @param {any} target 
+ */
+function isObject (target) {
+    return toString.call(target) === '[object Object]';
+}
+
+/**
+ * 是否是布朗类型
+ * @param {any} target 
+ */
+function isBoolean (target) {
+    return typeof target === 'boolean';
+}
+
+/**
+ * 是否是数字
+ * @param {any} target 
+ */
+function isNumber (target) {
+    return typeof target === 'number';
+}
+
+/**
+ * 是否是null
+ * @param {any} target 
+ */
+function isNull (target) {
+    return target === null;
 }

--- a/webview/utils.js
+++ b/webview/utils.js
@@ -1,0 +1,111 @@
+/* index(0) */
+
+/* 公共js工具 */
+
+/**
+ * 数据转换为blob
+*/
+function dataToBlob (data, type) {}
+
+/**
+ * 防抖函数
+ * @param {Function} callback 
+ * @param {any} param 
+ * @returns 
+ */
+function debounce (callback, param) {
+    let timeout;
+    return function () {
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+        timeout = setTimeout(callback.bind(null, param), 300);
+    }
+}
+
+/**
+ * 创建元素
+ * @param {string} name
+*/
+function $create (name) {
+    return document.createElement(name);
+}
+
+/**
+ * 获取节点复数属性
+ * @param {HTMLElement} target 目标元素
+ * @param {string[]} options 需要获取的属性名数组
+ * @param {boolean} list 是否返回数组格式
+ * @returns {string[] | {[key: string]: string}}
+ */
+function complexGetAttr (target, options, list = true) {
+    if (!Array.isArray(options)) options = [];
+    if (!target || !target instanceof HTMLElement) return list ? new Array(options.length).fill(undefined) : options.reduce((obj, value) => {
+        obj[value] = undefined;
+        return obj;
+    }, {});
+    /** @type {string[]|{[key: string]: string}} */
+    let result = list ? [] : {};
+    options.forEach(key => {
+        // 除了通过getAttribute获取，还有可能是set、get获取
+        let value = target.hasAttribute(key) ? target.getAttribute(key) : (target[key] ?? undefined);
+        list ? result.push(value) : result[key] = value;
+    });
+    return result;
+}
+
+/**
+ * 设置复数节点属性
+ * @param {HTMLElement} target 
+ * @param {{[key: string]: string}|string} options
+ * @param {'css'|'cssProperty'|'text'} type css: 设置css属性; cssProperty：设置css变量；text：设置文本
+ * @returns {HTMLElement}
+ */
+function complexSetAttr (target, options, type) {
+    if (!target || !target instanceof HTMLElement) return;
+    if (type === 'text' && typeof options === 'string') {
+        // 设置文本
+        target.innerText = options;
+        return target;
+    }
+    if (!toString.call(options) === '[object Object]') return target;
+    for (let key in options) {
+        if (!key) continue;
+        let value = options[key];
+        if (type === 'css') {
+            // 设置css样式
+            target.style.hasOwnProperty(key) ? target.style[key] = value : null;
+            continue;
+        }
+        if (type === 'cssProperty') {
+            // 设置css变量
+            target.style.setProperty(key, value);
+            continue;
+        }
+        target.setAttribute(key, value);
+    }
+    return target;
+}
+
+/**
+ * 将复数节点插入根节点
+ * @param {HTMLElement|ShadowRoot} target dom节点或者阴影根节点
+ * @param {HTMLElement[]} list 
+ * @returns {HTMLElement}
+ */
+function complexAppendChild (target, list) {
+    if (!target || !target instanceof HTMLElement || !target instanceof ShadowRoot) return;
+    if (!Array.isArray(list)) {
+        if (list && list instanceof HTMLElement) {
+            list = [list];
+        } else {
+            return target
+        }
+    };
+    for (let i = 0; i < list.length; i++) {
+        let dom = list[i];
+        if (!dom || !dom instanceof HTMLElement) continue;
+        target.appendChild(dom);
+    }
+    return target;
+}

--- a/webview/vscode.css
+++ b/webview/vscode.css
@@ -1,3 +1,5 @@
+/* index(1) */
+
 :root {
 	--container-paddding: 20px;
 	--input-padding-vertical: 6px;


### PR DESCRIPTION
1、图片路径改为blob数据路径，在webview侧进行base64到blob的转换。
2、调整扩展侧的逻辑，初始化时只传递所有图片哈希码的数组。
3、webview侧对图片显示区域进行监听，位于可视区域时，向扩展侧发送请求，通过哈希码获取具体base64数据。
4、大图查看也对图片路径进行blob转换。
5、修改文件储存路径后重置配置项的储存数据。
6、webview侧封装公用函数，对部分功能进行公用函数替换。
7、部分函数写法修改。