### PR TITLE
外置json文件重命名

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -20,7 +20,7 @@ webview/*.css
 webview/*.js
 test/**
 filePackage/**
-fileicons/**
+themes/**
 out/**
 dist/**
 !dist/extension.js

--- a/fileicons/wyg-icon-theme.json
+++ b/fileicons/wyg-icon-theme.json
@@ -1,7 +1,0 @@
-{
-    "iconDefinitions": {
-        "wyg": {
-            "iconPath": "../resources/svg/icon.svg"
-        }
-    }
-}


### PR DESCRIPTION
修改透明背景色显示背景图片测试失败，效果未复现。
结论：经过多次测试，判断实验时的效果呈现可能是设置了`monaco-workbench`类中的某个子元素的透明度，导致可以通过修改`monaco-workbench`的背景色控制背景图的深浅。
在找到更合适解决方案前继续沿用`body`透明度的设置，但是后续可以考虑将`body`中的透明度放至`monaco-workbench`类中，渲染性能应该能得到提升。